### PR TITLE
Fix pin assignments for lighting and encoder

### DIFF
--- a/keyboards/aki27/cocot46plus/keyboard.json
+++ b/keyboards/aki27/cocot46plus/keyboard.json
@@ -26,12 +26,12 @@
     "rgblight": true
   },
   "ws2812": {
-    "pin": "GP7",
+    "pin": "GP21",
     "driver": "vendor"
   },
   "encoder": {
     "rotary": [
-       { "pin_a": "GP0", "pin_b": "GP0"}
+       { "pin_a": "GP0", "pin_b": "GP1"}
     ]
   },
   "rgblight": {


### PR DESCRIPTION
I looked into the lighting issue, and noticed that I mistook PE6 for PB6 in Pro Micro's datasheet. Layer-wise lighting is now working on my board!

Also, the fix for this typo is applied in this PR: https://github.com/yudai-nkt/qmk_firmware/commit/8ec47dbe2e6e4fddaa55068699d4e29efd14fe30#r144545088